### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#chartjunk
+# chartjunk
 
 A while ago I made a sparkline font at the khan academy when i was working with [david hu](http://david-hu.com/) on creating more forgiving streak bars. Instead of writing some obtuse homebrew canvas script that would be hard to maintain i thought: why not use a font to represent the same thing? The text then, could be meaningful, and you'd have the advantage that the sparkline display would gracefully degrade.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
